### PR TITLE
redirect to root if REQUEST_URI is empty

### DIFF
--- a/wp-force-login.php
+++ b/wp-force-login.php
@@ -27,7 +27,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 function v_getUrl() {
   $url  = @( $_SERVER["HTTPS"] != 'on' ) ? 'http://'.$_SERVER["SERVER_NAME"] : 'https://'.$_SERVER["SERVER_NAME"];
-  $url .= $_SERVER["REQUEST_URI"];
+
+  // Redirect to root if no REQUEST_URI set:
+  if ( empty($_SERVER['REQUEST_URI']) ) {
+    $url .= '/';
+  } else {
+    $url .= $_SERVER['REQUEST_URI'];
+  }
+
   return $url;
 }
 function v_forcelogin() {


### PR DESCRIPTION
I turned on this module (thanks!) but http://site.example.com/ was setting REQUEST_URI to null, which meant wp_login was getting an empty URL.

At least for my use case I don't want people to show up at /wp-admin/ -- I'd instead like for them to go back to whatever the URL was.