### PR TITLE
Hide wp-login.php's back to blog link

### DIFF
--- a/wp-force-login.php
+++ b/wp-force-login.php
@@ -62,3 +62,10 @@ function v_forcelogin() {
   }
 }
 add_action('init', 'v_forcelogin');
+
+function v_forcelogin_hide_back_to_blog() { ?>
+  <style type="text/css">
+    #backtoblog { display: none; }
+  </style>
+<?php }
+add_action('login_enqueue_scripts', 'v_forcelogin_hide_back_to_blog');


### PR DESCRIPTION
**Because:**

* When the plugin is enabled the "← Back to {sitename}" link doesn't
  actually take you back to the site, it brings you back to the login
  page. This is confusing.

**This change:**

* Hides the link with CSS as there is no hook or filter currently
  available in the wp-login.php to remove it from the markup, ref:
  https://github.com/WordPress/WordPress/blob/4.5.2/wp-login.php#L222