### PR TITLE
Add bypass filter

### DIFF
--- a/wp-force-login.php
+++ b/wp-force-login.php
@@ -48,11 +48,12 @@ function v_forcelogin() {
     $url .= $_SERVER['REQUEST_URI'];
 
     // Apply filters
+    $bypass = apply_filters ( 'v_forcelogin_bypass', false );
     $whitelist = apply_filters( 'v_forcelogin_whitelist', array() );
     $redirect_url = apply_filters( 'v_forcelogin_redirect', $url );
 
     // Redirect visitors
-    if ( preg_replace('/\?.*/', '', $url) != preg_replace('/\?.*/', '', wp_login_url()) && !in_array($url, $whitelist) ) {
+    if ( preg_replace('/\?.*/', '', $url) != preg_replace('/\?.*/', '', wp_login_url()) && !in_array($url, $whitelist) && !$bypass ) {
       wp_safe_redirect( wp_login_url( $redirect_url ), 302 ); exit();
     }
   }


### PR DESCRIPTION
There are scenarios where you may need to bypass the login form on criteria other than URL path, for example; a monitoring tool that identifies itself by a key value in a custom HTTP header.

Technically this functionality could be delivered with the existing `v_forcelogin_whitelist` filter, as you could create a dynamic whitelist based on other information in the request, but I think it would be nicer to add a hook specifically to support custom bypasses of this nature.

What do you think?