### PR TITLE
Return unauthorized status code on REST API request

### DIFF
--- a/wp-force-login.php
+++ b/wp-force-login.php
@@ -68,13 +68,15 @@ function v_forcelogin() {
 }
 add_action('template_redirect', 'v_forcelogin');
 
-function v_forcelogin_rest() {
+function v_forcelogin_rest_access( $result ) {
   if ( !is_user_logged_in() ) {
     return new WP_Error(
       'rest_unauthorized',
-      __( 'Sorry, you are not authorized to do that.', 'wp-force-login' ),
-      array( 'status' => 401 )
+      __( 'Only authenticated users can access the REST API.', 'wp-force-login' ),
+      array( 'status' => rest_authorization_required_code() )
     );
   }
+
+  return $result;
 }
-add_action('rest_request_before_callbacks','v_forcelogin_rest');
+add_filter( 'rest_authentication_errors', 'v_forcelogin_rest_access' );

--- a/wp-force-login.php
+++ b/wp-force-login.php
@@ -67,3 +67,14 @@ function v_forcelogin() {
   }
 }
 add_action('template_redirect', 'v_forcelogin');
+
+function v_forcelogin_rest() {
+  if ( !is_user_logged_in() ) {
+    return new WP_Error(
+      'rest_unauthorized',
+      __( 'Sorry, you are not authorized to do that.', 'wp-force-login' ),
+      array( 'status' => 401 )
+    );
+  }
+}
+add_action('rest_request_before_callbacks','v_forcelogin_rest');


### PR DESCRIPTION
Installing the plugin, I found that content of my site could still be accessed via the REST API. Would it be within scope of the plugin to restrict access to the API as well? The proposed changes here return a 401 status code (Unauthorized) when attempting to request any REST endpoint while unauthenticated.