### PR TITLE
Call WP's nocache_headers to prevent redirection browser caching

### DIFF
--- a/wp-force-login.php
+++ b/wp-force-login.php
@@ -44,8 +44,14 @@ function v_forcelogin() {
 
     // Redirect
     if ( preg_replace( '/\?.*/', '', $url ) != preg_replace( '/\?.*/', '', wp_login_url() ) && ! in_array( $url, $whitelist ) && ! $bypass ) {
+      // Determine redirect URL
       $redirect_url = apply_filters( 'v_forcelogin_redirect', $url );
-      wp_safe_redirect( wp_login_url( $redirect_url ), 302 ); exit;
+      // Set the headers to prevent caching for the different browsers
+      nocache_headers();
+      // Redirect
+      wp_safe_redirect( wp_login_url( $redirect_url ), 302 );
+      // Stop PHP for the redirect to occur
+      exit;
     }
   }
   elseif ( function_exists('is_multisite') && is_multisite() ) {


### PR DESCRIPTION
We include server side `ExpiresByType` directives in our WordPress installation .htaccess files, to prevent the browser from returning to the server unless needed.

For text/html (i.e. WP content) responses, we set the browser caching to 10 minutes.

```
ExpiresByType text/html "access plus 600 seconds"
```

The wp-force-login 302 redirection response winds up getting cached by the browser for 10 minutes.  For example, if you visit the homepage and are forced to log in, returning to the homepage will immediately send you back to the WP login URL.

```
curl --head https://DOMAIN.org
HTTP/1.1 302 Found
Date: Tue, 16 Oct 2018 20:15:45 GMT
Server: Apache
Location: https://DOMAIN.org/wp-login.php?redirect_to=https%3A%2F%2FDOMAIN.org%2F
Cache-Control: max-age=600
Expires: Tue, 16 Oct 2018 20:25:45 GMT
Strict-Transport-Security: max-age=31536000
Vary: Accept-Encoding
Content-Type: text/html; charset=UTF-8
```

This PR calls WordPress' built in [`nocache_headers()` function](https://codex.wordpress.org/Function_Reference/nocache_headers), which is intended specifically to prevent browser caching.

After applying the change, you can see the cache headers prevent caching. Apache .htaccess caching directives are the default, overruled by WP's explicit headers.

```
curl --head https://DOMAIN
HTTP/1.1 302 Found
Date: Tue, 16 Oct 2018 20:19:05 GMT
Server: Apache
Expires: Wed, 11 Jan 1984 05:00:00 GMT
Cache-Control: no-cache, must-revalidate, max-age=0
Location: https://DOMAIN.org/wp-login.php?redirect_to=https%3A%2F%2FDOMAIN.org%2F
Strict-Transport-Security: max-age=31536000
Vary: Accept-Encoding
Content-Type: text/html; charset=UTF-8
```