### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/wp-force-login.php
+++ b/wp-force-login.php
@@ -27,7 +27,7 @@ function v_forcelogin() {
 		$url  = isset( $_SERVER['HTTPS'] ) && 'on' === $_SERVER['HTTPS'] ? 'https' : 'http';
 		$url .= '://' . $_SERVER['HTTP_HOST'];
 		// port is prepopulated here sometimes
-		if ( strpos( $_SERVER['HTTP_HOST'], ':' ) === FALSE ) {
+		if ( strpos( $_SERVER['HTTP_HOST'], ':' ) === false ) {
 			$url .= in_array( $_SERVER['SERVER_PORT'], array('80', '443') ) ? '' : ':' . $_SERVER['SERVER_PORT'];
 		}
 		$url .= $_SERVER['REQUEST_URI'];


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!