### PR TITLE
Add filter that disables the members-only access check

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Force Login ===
+Update readme.txt to describe ne=== Force Login ===
 Contributors: kevinvess
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=forcelogin%40vess%2eme&lc=US&item_name=Force%20Login%20for%20WordPress&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted
 Tags: privacy, private, protected, registered only, restricted, access, closed, force user login, hidden, login, password
@@ -141,6 +141,21 @@ function my_forcelogin_hide_backtoblog() {
 add_action( 'login_enqueue_scripts', 'my_forcelogin_hide_backtoblog' );
 `
 
+= 6. How do I disable the requirement for users to be members of the site they are authenticating to for Multisite Setups?
+
+By default, when used in a multisite setup, each site requires authenication and only members of a given site have access to view the site.
+
+`
+/**
+ * Filter Force Login to allow require or unrequire multisite users to be members of the site they are trying to access.
+ *
+ * @return bool
+ */
+function my_forcelogin_multisite_members_only() {
+  return false;
+}
+add_filter( 'v_forcelogin_multisite_members_only', 'my_forcelogin_multisite_members_only' );
+`
 
 == Changelog ==
 
@@ -226,3 +241,4 @@ New features: added filters for customizing the plugin.
 
 = 2.0 =
 New feature: added redirect to send visitors back to the URL they tried to visit after logging-in.
+w option

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-Update readme.txt to describe ne=== Force Login ===
+=== Force Login ===
 Contributors: kevinvess
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=forcelogin%40vess%2eme&lc=US&item_name=Force%20Login%20for%20WordPress&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted
 Tags: privacy, private, protected, registered only, restricted, access, closed, force user login, hidden, login, password
@@ -241,4 +241,3 @@ New features: added filters for customizing the plugin.
 
 = 2.0 =
 New feature: added redirect to send visitors back to the URL they tried to visit after logging-in.
-w option

--- a/readme.txt
+++ b/readme.txt
@@ -147,7 +147,7 @@ By default, when used in a multisite setup, each site requires authenication and
 
 `
 /**
- * Filter Force Login to allow require or unrequire multisite users to be members of the site they are trying to access.
+ * Filter Force Login to check that multisite users are members of the site they are trying to access.
  *
  * @return bool
  */

--- a/wp-force-login.php
+++ b/wp-force-login.php
@@ -51,7 +51,7 @@ function v_forcelogin() {
 			wp_safe_redirect( wp_login_url( $redirect_url ), 302 ); exit;
 		}
 	}
-	elseif ( function_exists('is_multisite') && is_multisite() ) {
+	elseif ( apply_filters( 'v_forcelogin_multisite_members_only', true ) && function_exists('is_multisite') && is_multisite() ) {
 		// Only allow Multisite users access to their assigned sites
 		if ( ! is_user_member_of_blog() && ! current_user_can('setup_network') ) {
 			wp_die( __( "You're not authorized to access this site.", 'wp-force-login' ), get_option('blogname') . ' &rsaquo; ' . __( "Error", 'wp-force-login' ) );


### PR DESCRIPTION
Currently this plugin requires authentication and if multisite, also requires the user to be a member of the site they are trying to view. I've added a filter that will allow this to be disabled so that only authentication is required to view the sites.
This is useful for multisite setups where you already control who has accounts and just want to block anonymous traffic to the sites.