### PR TITLE
added bypass filter for REST requests

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -71,6 +71,21 @@ function my_forcelogin_bypass( $bypass, $visited_url ) {
 add_filter( 'v_forcelogin_bypass', 'my_forcelogin_bypass', 10, 2 );
 `
 
+To bypass Force Login on any REST requests, please use a seperate filter.
+
+`
+/**
+ * Bypass Force Login for REST requests.
+ *
+ * @param bool $bypass Whether to disable Force Login for REST requests. Default false.
+ * @return bool
+ */
+
+function my_forcelogin_bypass_rest($bypass) {
+    return true;
+}
+add_filter('v_forcelogin_bypass_rest', 'my_forcelogin_bypass_rest', 10, 2);
+
 Check out the [Force Login Wiki on GitHub](https://github.com/kevinvess/wp-force-login/wiki) for additional examples to allow URLs to be publicly accessible.
 
 = 3. How do I hide the "← Back to {sitename}" link? =

--- a/wp-force-login.php
+++ b/wp-force-login.php
@@ -92,6 +92,18 @@ add_action( 'template_redirect', 'v_forcelogin' );
  * @return WP_Error|null|bool
  */
 function v_forcelogin_rest_access( $result ) {
+	
+	/**
+	 * Bypass filter for REST access.
+	 *
+	 * @param bool Whether to disable Force Login for REST requests. Default false.
+	 */
+	$bypass = apply_filters( 'v_forcelogin_bypass_rest', false);
+
+	// Bail if bypass is enabled for REST
+	if ( $bypass ) {
+		return;
+	}
 	if ( null === $result && ! is_user_logged_in() ) {
 		return new WP_Error( 'rest_unauthorized', __( 'Only authenticated users can access the REST API.', 'wp-force-login' ), array( 'status' => rest_authorization_required_code() ) );
 	}


### PR DESCRIPTION
I've added a separate filter to bypass the plugin on REST requests after I noticed I wasn't able to do this via the existing filter hook. Found out it was a separate action, and made a separate filter for this.

```
function v_forcelogin_rest_access( $result ) {

	$bypass = apply_filters( 'v_forcelogin_bypass_rest', false);
	if ( $bypass ) {
		return;
	}
	if ( null === $result && ! is_user_logged_in() ) {
	...
}
add_filter( 'rest_authentication_errors', 'v_forcelogin_rest_access', 99 );
```

Usage: 

```
function my_forcelogin_bypass_rest($bypass) {
    return true;
}
add_filter('v_forcelogin_bypass_rest', 'my_forcelogin_bypass_rest', 10, 2);

```